### PR TITLE
Support all and validation

### DIFF
--- a/jab-modules.sln.DotSettings
+++ b/jab-modules.sln.DotSettings
@@ -1,0 +1,2 @@
+﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+	<s:Boolean x:Key="/Default/Environment/Filtering/ExcludeCoverageFilters/=Raiqub_002EJabModules_002EMicrosoftExtensionsOptions_003B_002A_003BJab_002E_002A_003B_002A/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>

--- a/src/MicrosoftExtensionsOptions/IOptionsModule.cs
+++ b/src/MicrosoftExtensionsOptions/IOptionsModule.cs
@@ -40,6 +40,16 @@ public interface IOptionsModule
         new ConfigureNamedOptions<TOptions>(name, configureOptions);
 
     /// <summary>
+    /// Registers an action used to configure all instances of a particular type of options.
+    /// </summary>
+    /// <param name="configureOptions">The action used to configure the options.</param>
+    /// <typeparam name="TOptions">The options type to be configured.</typeparam>
+    /// <returns>The configuration to configure the <typeparamref name="TOptions"/> type.</returns>
+    public static IConfigureOptions<TOptions> ConfigureAll<TOptions>(Action<TOptions> configureOptions)
+        where TOptions : class =>
+        Configure(name: null, configureOptions);
+
+    /// <summary>
     /// Registers an action used to configure a particular type of options.
     /// These are run after <see cref="Configure{TOptions}(System.Action{TOptions})"/>.
     /// </summary>
@@ -63,4 +73,67 @@ public interface IOptionsModule
         Action<TOptions> configureOptions)
         where TOptions : class =>
         new PostConfigureOptions<TOptions>(name, configureOptions);
+
+    /// <summary>
+    /// Registers an action used to post configure all instances of a particular type of options.
+    /// Note: These are run after all <see cref="Configure{TOptions}(Action{TOptions})"/>.
+    /// </summary>
+    /// <param name="configureOptions">The action used to configure the options.</param>
+    /// <typeparam name="TOptions">The options type to be configure.</typeparam>
+    /// <returns>The configuration to configure the <typeparamref name="TOptions"/> type.</returns>
+    public static IPostConfigureOptions<TOptions> PostConfigureAll<TOptions>(Action<TOptions> configureOptions)
+        where TOptions : class =>
+        PostConfigure(name: null, configureOptions);
+
+    /// <summary>
+    /// Register a validation action for an options type.
+    /// </summary>
+    /// <param name="validation">The validation function.</param>
+    /// <typeparam name="TOptions">The options type to be configure.</typeparam>
+    /// <returns>The validator used to validate the <typeparamref name="TOptions"/> type.</returns>
+    public static IValidateOptions<TOptions> Validate<TOptions>(
+        Func<TOptions, bool> validation)
+        where TOptions : class =>
+        new ValidateOptions<TOptions>(Options.DefaultName, validation, OptionsBuilderAccessor.DefaultValidationFailureMessage);
+
+    /// <summary>
+    /// Register a validation action for an options type.
+    /// </summary>
+    /// <param name="validation">The validation function.</param>
+    /// <param name="failureMessage">The failure message to use when validation fails.</param>
+    /// <typeparam name="TOptions">The options type to be configure.</typeparam>
+    /// <returns>The validator used to validate the <typeparamref name="TOptions"/> type.</returns>
+    public static IValidateOptions<TOptions> Validate<TOptions>(
+        Func<TOptions, bool> validation,
+        string failureMessage)
+        where TOptions : class =>
+        new ValidateOptions<TOptions>(Options.DefaultName, validation, failureMessage);
+
+    /// <summary>
+    /// Register a validation action for an options type.
+    /// </summary>
+    /// <param name="name">The name of the options instance.</param>
+    /// <param name="validation">The validation function.</param>
+    /// <typeparam name="TOptions">The options type to be configure.</typeparam>
+    /// <returns>The validator used to validate the <typeparamref name="TOptions"/> type.</returns>
+    public static IValidateOptions<TOptions> Validate<TOptions>(
+        string? name,
+        Func<TOptions, bool> validation)
+        where TOptions : class =>
+        new ValidateOptions<TOptions>(name, validation, OptionsBuilderAccessor.DefaultValidationFailureMessage);
+
+    /// <summary>
+    /// Register a validation action for an options type.
+    /// </summary>
+    /// <param name="name">The name of the options instance.</param>
+    /// <param name="validation">The validation function.</param>
+    /// <param name="failureMessage">The failure message to use when validation fails.</param>
+    /// <typeparam name="TOptions">The options type to be configure.</typeparam>
+    /// <returns>The validator used to validate the <typeparamref name="TOptions"/> type.</returns>
+    public static IValidateOptions<TOptions> Validate<TOptions>(
+        string? name,
+        Func<TOptions, bool> validation,
+        string failureMessage)
+        where TOptions : class =>
+        new ValidateOptions<TOptions>(name, validation, failureMessage);
 }

--- a/src/MicrosoftExtensionsOptions/MicrosoftExtensionsOptions.csproj
+++ b/src/MicrosoftExtensionsOptions/MicrosoftExtensionsOptions.csproj
@@ -1,14 +1,19 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-    <PropertyGroup>
-        <TargetFramework>net8.0</TargetFramework>
-        <ImplicitUsings>enable</ImplicitUsings>
-        <Nullable>enable</Nullable>
-    </PropertyGroup>
+  <PropertyGroup>
+    <TargetFrameworks>net8.0;net6.0</TargetFrameworks>
+  </PropertyGroup>
 
-    <ItemGroup>
-      <PackageReference Include="Jab" Version="0.8.7" />
-      <PackageReference Include="Microsoft.Extensions.Options" Version="8.0.0" />
-    </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Jab" Version="0.8.7" />
+  </ItemGroup>
+
+  <ItemGroup Condition="$(TargetFramework) == 'net8.0'">
+    <PackageReference Include="Microsoft.Extensions.Options" Version="8.0.0" />
+  </ItemGroup>
+
+  <ItemGroup Condition="$(TargetFramework) == 'net6.0'">
+    <PackageReference Include="Microsoft.Extensions.Options" Version="6.0.0" />
+  </ItemGroup>
 
 </Project>

--- a/src/MicrosoftExtensionsOptions/OptionsBuilderAccessor.cs
+++ b/src/MicrosoftExtensionsOptions/OptionsBuilderAccessor.cs
@@ -1,0 +1,6 @@
+﻿namespace Raiqub.JabModules.MicrosoftExtensionsOptions;
+
+internal static class OptionsBuilderAccessor
+{
+    public const string DefaultValidationFailureMessage = "A validation error has occurred.";
+}

--- a/tests/Directory.Build.props
+++ b/tests/Directory.Build.props
@@ -10,4 +10,10 @@
     <NoWarn>$(NoWarn);CA1716</NoWarn>
   </PropertyGroup>
 
+  <ItemGroup>
+    <AssemblyAttribute Include="System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute" />
+    <Using Include="FluentAssertions" />
+    <Using Include="Xunit" />
+  </ItemGroup>
+
 </Project>

--- a/tests/Directory.Build.props
+++ b/tests/Directory.Build.props
@@ -5,6 +5,7 @@
   <PropertyGroup>
     <IsPackable>false</IsPackable>
     <IsPublishable>false</IsPublishable>
+    <IsTestProject>true</IsTestProject>
     <EnableNETAnalyzers>false</EnableNETAnalyzers>
     <NoWarn>$(NoWarn);CA1716</NoWarn>
   </PropertyGroup>

--- a/tests/MicrosoftExtensionsOptions.Tests/Examples/FooContainerDefault.cs
+++ b/tests/MicrosoftExtensionsOptions.Tests/Examples/FooContainerDefault.cs
@@ -1,0 +1,8 @@
+﻿using Jab;
+
+namespace Raiqub.JabModules.MicrosoftExtensionsOptions.Tests.Examples;
+
+[ServiceProvider]
+[Import<IOptionsModule>]
+[Singleton<FooService>]
+public sealed partial class FooContainerDefault;

--- a/tests/MicrosoftExtensionsOptions.Tests/Examples/FooInvalidNamedOptionsWithMessageContainer.cs
+++ b/tests/MicrosoftExtensionsOptions.Tests/Examples/FooInvalidNamedOptionsWithMessageContainer.cs
@@ -1,0 +1,18 @@
+﻿using Jab;
+using Microsoft.Extensions.Options;
+
+namespace Raiqub.JabModules.MicrosoftExtensionsOptions.Tests.Examples;
+
+[ServiceProvider]
+[Import<IOptionsModule>]
+[Scoped<FooServiceNamed>]
+[Transient<IConfigureOptions<FooOptions>>(Factory = nameof(ConfigureFoo))]
+[Transient<IValidateOptions<FooOptions>>(Factory = nameof(ValidateFoo))]
+public sealed partial class FooInvalidNamedOptionsWithMessageContainer
+{
+    private static IConfigureOptions<FooOptions> ConfigureFoo() =>
+        IOptionsModule.Configure<FooOptions>("Foo", options => options.Name = "Jane");
+
+    private static IValidateOptions<FooOptions> ValidateFoo() =>
+        IOptionsModule.Validate<FooOptions>("Foo", options => options.Name != "Jane", "Name is not Jane");
+}

--- a/tests/MicrosoftExtensionsOptions.Tests/Examples/FooInvalidOptionsContainer.cs
+++ b/tests/MicrosoftExtensionsOptions.Tests/Examples/FooInvalidOptionsContainer.cs
@@ -8,11 +8,11 @@ namespace Raiqub.JabModules.MicrosoftExtensionsOptions.Tests.Examples;
 [Singleton<FooService>]
 [Transient<IConfigureOptions<FooOptions>>(Factory = nameof(ConfigureFoo))]
 [Transient<IValidateOptions<FooOptions>>(Factory = nameof(ValidateFoo))]
-public sealed partial class FooContainer
+public sealed partial class FooInvalidOptionsContainer
 {
     private static IConfigureOptions<FooOptions> ConfigureFoo() =>
         IOptionsModule.Configure<FooOptions>(options => options.Name = "Jane");
 
     private static IValidateOptions<FooOptions> ValidateFoo() =>
-        IOptionsModule.Validate<FooOptions>(options => options.Name == "Jane");
+        IOptionsModule.Validate<FooOptions>(options => options.Name != "Jane");
 }

--- a/tests/MicrosoftExtensionsOptions.Tests/Examples/FooInvalidOptionsWithMessageContainer.cs
+++ b/tests/MicrosoftExtensionsOptions.Tests/Examples/FooInvalidOptionsWithMessageContainer.cs
@@ -7,16 +7,12 @@ namespace Raiqub.JabModules.MicrosoftExtensionsOptions.Tests.Examples;
 [Import<IOptionsModule>]
 [Singleton<FooService>]
 [Transient<IConfigureOptions<FooOptions>>(Factory = nameof(ConfigureFoo))]
-[Transient<IPostConfigureOptions<FooOptions>>(Factory = nameof(PostConfigureFoo))]
 [Transient<IValidateOptions<FooOptions>>(Factory = nameof(ValidateFoo))]
-public sealed partial class FooContainer
+public sealed partial class FooInvalidOptionsWithMessageContainer
 {
     private static IConfigureOptions<FooOptions> ConfigureFoo() =>
         IOptionsModule.Configure<FooOptions>(options => options.Name = "Jane");
 
-    private static IPostConfigureOptions<FooOptions> PostConfigureFoo() =>
-        IOptionsModule.PostConfigure<FooOptions>(options => options.Name += " Doe");
-
     private static IValidateOptions<FooOptions> ValidateFoo() =>
-        IOptionsModule.Validate<FooOptions>(options => options.Name == "Jane Doe");
+        IOptionsModule.Validate<FooOptions>(options => options.Name != "Jane", "Name is not Jane");
 }

--- a/tests/MicrosoftExtensionsOptions.Tests/Examples/FooNamedContainer.cs
+++ b/tests/MicrosoftExtensionsOptions.Tests/Examples/FooNamedContainer.cs
@@ -1,0 +1,34 @@
+﻿using Jab;
+using Microsoft.Extensions.Options;
+
+namespace Raiqub.JabModules.MicrosoftExtensionsOptions.Tests.Examples;
+
+[ServiceProvider]
+[Import<IOptionsModule>]
+[Scoped<FooServiceNamed>]
+[Transient<IConfigureOptions<FooOptions>>(Factory = nameof(ConfigureFoo))]
+[Transient<IConfigureOptions<FooOptions>>(Factory = nameof(ConfigureIgnored))]
+[Transient<IConfigureOptions<FooOptions>>(Factory = nameof(ConfigureFooNamed))]
+[Transient<IPostConfigureOptions<FooOptions>>(Factory = nameof(PostConfigureFoo))]
+[Transient<IPostConfigureOptions<FooOptions>>(Factory = nameof(PostConfigureFooNamed))]
+[Transient<IValidateOptions<FooOptions>>(Factory = nameof(ValidateFoo))]
+public sealed partial class FooNamedContainer
+{
+    private static IConfigureOptions<FooOptions> ConfigureFoo() =>
+        IOptionsModule.ConfigureAll<FooOptions>(options => options.Name = "J");
+
+    private static IConfigureOptions<FooOptions> ConfigureIgnored() =>
+        IOptionsModule.Configure<FooOptions>("Other", options => options.Name += "ohn");
+
+    private static IConfigureOptions<FooOptions> ConfigureFooNamed() =>
+        IOptionsModule.Configure<FooOptions>("Foo", options => options.Name += "ane");
+
+    private static IPostConfigureOptions<FooOptions> PostConfigureFoo() =>
+        IOptionsModule.PostConfigureAll<FooOptions>(options => options.Name += " ");
+
+    private static IPostConfigureOptions<FooOptions> PostConfigureFooNamed() =>
+        IOptionsModule.PostConfigure<FooOptions>("Foo", options => options.Name += "Doe");
+
+    private static IValidateOptions<FooOptions> ValidateFoo() =>
+        IOptionsModule.Validate<FooOptions>("Foo", options => options.Name == "Jane Doe");
+}

--- a/tests/MicrosoftExtensionsOptions.Tests/Examples/FooServiceNamed.cs
+++ b/tests/MicrosoftExtensionsOptions.Tests/Examples/FooServiceNamed.cs
@@ -1,0 +1,8 @@
+﻿using Microsoft.Extensions.Options;
+
+namespace Raiqub.JabModules.MicrosoftExtensionsOptions.Tests.Examples;
+
+public class FooServiceNamed(IOptionsSnapshot<FooOptions> options)
+{
+    public string Call() => $"Hello {options.Get("Foo").Name}";
+}

--- a/tests/MicrosoftExtensionsOptions.Tests/Examples/FooServiceProvider.cs
+++ b/tests/MicrosoftExtensionsOptions.Tests/Examples/FooServiceProvider.cs
@@ -1,0 +1,17 @@
+﻿using Microsoft.Extensions.DependencyInjection;
+
+namespace Raiqub.JabModules.MicrosoftExtensionsOptions.Tests.Examples;
+
+public class FooServiceProvider : IServiceProvider
+{
+    private readonly ServiceProvider _serviceProvider;
+
+    public FooServiceProvider()
+    {
+        _serviceProvider = new ServiceCollection()
+            .Configure<FooOptions>(options => options.Name = "Jane")
+            .BuildServiceProvider();
+    }
+
+    public object? GetService(Type serviceType) => _serviceProvider.GetService(serviceType);
+}

--- a/tests/MicrosoftExtensionsOptions.Tests/MicrosoftExtensionsOptions.Tests.csproj
+++ b/tests/MicrosoftExtensionsOptions.Tests/MicrosoftExtensionsOptions.Tests.csproj
@@ -1,35 +1,31 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-    <PropertyGroup>
-        <TargetFramework>net8.0</TargetFramework>
-        <ImplicitUsings>enable</ImplicitUsings>
-        <Nullable>enable</Nullable>
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+  </PropertyGroup>
 
-        <IsPackable>false</IsPackable>
-        <IsTestProject>true</IsTestProject>
-    </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="coverlet.msbuild" Version="6.0.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="FluentAssertions" Version="6.12.0" />
+    <PackageReference Include="Jab" Version="0.8.7" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="xunit" Version="2.6.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.4">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="6.0.0">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
 
-    <ItemGroup>
-        <PackageReference Include="coverlet.msbuild" Version="6.0.0">
-          <PrivateAssets>all</PrivateAssets>
-          <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-        </PackageReference>
-        <PackageReference Include="FluentAssertions" Version="6.12.0" />
-        <PackageReference Include="Jab" Version="0.8.7" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
-        <PackageReference Include="xunit" Version="2.6.2" />
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.5.4">
-            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-            <PrivateAssets>all</PrivateAssets>
-        </PackageReference>
-        <PackageReference Include="coverlet.collector" Version="6.0.0">
-            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-            <PrivateAssets>all</PrivateAssets>
-        </PackageReference>
-    </ItemGroup>
-
-    <ItemGroup>
-      <ProjectReference Include="..\..\src\MicrosoftExtensionsOptions\MicrosoftExtensionsOptions.csproj" />
-    </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\MicrosoftExtensionsOptions\MicrosoftExtensionsOptions.csproj" />
+  </ItemGroup>
 
 </Project>

--- a/tests/MicrosoftExtensionsOptions.Tests/OptionsModuleTest.cs
+++ b/tests/MicrosoftExtensionsOptions.Tests/OptionsModuleTest.cs
@@ -1,8 +1,6 @@
-﻿using FluentAssertions;
-using Microsoft.Extensions.DependencyInjection;
+﻿using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 using Raiqub.JabModules.MicrosoftExtensionsOptions.Tests.Examples;
-using Xunit;
 
 namespace Raiqub.JabModules.MicrosoftExtensionsOptions.Tests;
 
@@ -16,7 +14,7 @@ public class OptionsModuleTest
 
         string result = fooService.Call();
 
-        result.Should().Be("Hello Jane");
+        result.Should().Be("Hello Jane Doe");
     }
 
     [Fact]
@@ -39,5 +37,40 @@ public class OptionsModuleTest
         Action call = () => fooService.Call();
 
         call.Should().ThrowExactly<OptionsValidationException>();
+    }
+
+    [Fact]
+    public void ShouldThrowInvalidOptionsWithMessageFoo()
+    {
+        using var container = new FooInvalidOptionsWithMessageContainer();
+        var fooService = container.GetRequiredService<FooService>();
+
+        Action call = () => fooService.Call();
+
+        call.Should().ThrowExactly<OptionsValidationException>().Where(e => e.Message == "Name is not Jane");
+    }
+
+    [Fact]
+    public void ShouldThrowInvalidNamedOptionsWithMessageFoo()
+    {
+        using var container = new FooInvalidNamedOptionsWithMessageContainer();
+        using var scope = container.CreateScope();
+        var fooService = scope.GetRequiredService<FooServiceNamed>();
+
+        Action call = () => fooService.Call();
+
+        call.Should().ThrowExactly<OptionsValidationException>().Where(e => e.Message == "Name is not Jane");
+    }
+
+    [Fact]
+    public void ShouldConfigureFooWithName()
+    {
+        using var container = new FooNamedContainer();
+        using var scope = container.CreateScope();
+        var fooService = scope.GetRequiredService<FooServiceNamed>();
+
+        string result = fooService.Call();
+
+        result.Should().Be("Hello Jane Doe");
     }
 }

--- a/tests/MicrosoftExtensionsOptions.Tests/OptionsModuleTest.cs
+++ b/tests/MicrosoftExtensionsOptions.Tests/OptionsModuleTest.cs
@@ -1,5 +1,6 @@
 ﻿using FluentAssertions;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
 using Raiqub.JabModules.MicrosoftExtensionsOptions.Tests.Examples;
 using Xunit;
 
@@ -16,5 +17,27 @@ public class OptionsModuleTest
         string result = fooService.Call();
 
         result.Should().Be("Hello Jane");
+    }
+
+    [Fact]
+    public void ShouldDefaultOptionsFoo()
+    {
+        using var container = new FooContainerDefault();
+        var fooService = container.GetRequiredService<FooService>();
+
+        string result = fooService.Call();
+
+        result.Should().Be("Hello John");
+    }
+
+    [Fact]
+    public void ShouldThrowInvalidOptionsFoo()
+    {
+        using var container = new FooInvalidOptionsContainer();
+        var fooService = container.GetRequiredService<FooService>();
+
+        Action call = () => fooService.Call();
+
+        call.Should().ThrowExactly<OptionsValidationException>();
     }
 }


### PR DESCRIPTION
<!-- Thank you for contributing to Raiqub JabModules!  Open source is only as strong as its contributors. -->

# Pull Request

## The issue or feature being addressed
- The methods `ConfigureAll`, `PostConfigureAll` and `Validate` are not supported

## Details on the issue fix or feature implementation
- Implemented missing methods and increase coverage

## Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [x]  I have included unit tests for the issue/feature
- [x]  I have successfully run a local build
